### PR TITLE
feat: support windows 2025 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,15 @@ jobs:
         run: npm run fmt-check
       - name: Run lint check
         run: npm run lint
+      - name: Run bundle
+        run: npm run bundle
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff --text -v
+            exit 1
+          fi
 
   audit:
     runs-on: ubuntu-latest
@@ -42,7 +51,11 @@ jobs:
       - run: npm audit --audit-level moderate --omit dev
 
   test-defaults:
-    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ windows-2022, windows-2025 ]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -50,7 +63,11 @@ jobs:
         uses: ./
 
   test-declare-inputs:
-    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ windows-2022, windows-2025 ]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -71,9 +88,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         drive-format: [ FAT, FAT32, exFAT, NTFS, ReFS ]
         with-mount-path: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -83,14 +101,17 @@ jobs:
           drive-format: ${{ matrix.drive-format }}
           # This should fall back to Drive Letter on unsupported drive formats.
           mount-path: ${{ matrix.with-mount-path && 'mount' || '' }}
+          # Ensure we test FS directly
+          native-dev-drive: false
 
   test-large-size:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         drive-type: [ Fixed, Dynamic ]
         with-mount-path: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -106,8 +127,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         with-mount-path: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -126,9 +148,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         is-relative: [ true, false ]
         drive-format: [ ReFS, NTFS ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -146,9 +169,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         with-mount-path: [ true, false ]
         workspace-copy: [ true ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -173,9 +197,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         with-mount-path: [ true, false ]
         workspace-copy: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -248,8 +273,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         with-mount-path: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -279,8 +305,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ windows-2022, windows-2025 ]
         with-mount-path: [ true, false ]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     needs: [test-cache-storage]
     steps:
       - name: Check out source code
@@ -306,7 +333,11 @@ jobs:
           }
 
   test-env-mapping:
-    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ windows-2022, windows-2025 ]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3.0
+
+* Add `windows-2025` runner support.
+* Change default VHDX size to 2GB.
+
 # 3.2.0
 
 * Add `env-mapping` option to support improved environment variables configuration.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ You can optionally pass parameters to the action as follows:
 ```yaml
 - uses: samypr100/setup-dev-drive@v3
   with:
-    # Drive size in bytes (or as a PowerShell numeric literal). Defaults to 1GB.
-    drive-size: 1GB
+    # Drive size in bytes (or as a PowerShell numeric literal). Defaults to 2GB.
+    drive-size: 2GB
     # Drive file system (ReFS, NTFS, etc.). Defaults to ReFS.
     drive-format: ReFS
     # Drive allocation (Dynamic or Fixed). Defaults to Dynamic.
@@ -68,7 +68,7 @@ For more examples, take a look in the dedicated [examples section](#examples).
 
 ### *drive-size*
 
-By default, this option is set to `1GB`.
+By default, this option is set to `2GB`.
 
 Allows you to configure the dev drive size in bytes. This is subject to the limit of space
 available on your runner. The default public runners roughly hold about 15GB of
@@ -76,7 +76,7 @@ available on your runner. The default public runners roughly hold about 15GB of
 so it's suggested you keep your drive size below that limit, or you may encounter errors.
 
 You can use PowerShell built in [Numeric Literals](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_numeric_literals)
-functionality to automatically expand expressions like `1GB` to mean `1073741824`.
+functionality to automatically expand expressions like `2GB` to mean `2147483648`.
 
 ### *drive-format*
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   drive-size:
     description: "Drive Size. Examples: 1GB, 3GB, 10GB."
-    default: "1GB"
+    default: "2GB"
   drive-format:
     description: "Drive Format. Examples: FAT, FAT32, exFAT, NTFS, ReFS."
     default: "ReFS"


### PR DESCRIPTION
* Adds support and testing for [Windows 2025 runners](https://github.com/actions/runner-images/blob/6cc2576b1b19c08317047523d5abe3c48a9eab98/images/windows/Windows2025-Readme.md)
* Change default VHDX size to allow native dev drive to have minimum supported capacity on the new runners
* Bump to version to 3.3.0